### PR TITLE
Add preemptive authorization

### DIFF
--- a/src/clj/http/async/client.clj
+++ b/src/clj/http/async/client.clj
@@ -44,10 +44,11 @@
       :password - (optional) password to use for proxy authentication,
                   has to be provided with :user
   - :auth :: map with authentication to be used
-      :type     - either :basic or :digest
-      :user     - user name to be used
-      :password - password to be used
-      :realm    - realm name to authenticate in
+      :type       - either :basic or :digest
+      :user       - user name to be used
+      :password   - password to be used
+      :realm      - realm name to authenticate in
+      :preemptive - assume authentication is required
   - :request-timeout :: request timeout in ms
   - :user-agent :: User-Agent branding string
   - :async-connect :: Execute connect asynchronously

--- a/src/clj/http/async/client/request.clj
+++ b/src/clj/http/async/client/request.clj
@@ -123,10 +123,11 @@
       :password - (optional) password to use for proxy authentication,
                   has to be provided with :user
     :auth    - map with authentication to be used
-      :type     - either :basic or :digest
-      :user     - user name to be used
-      :password - password to be used
-      :realm    - realm name to authenticate in
+      :type       - either :basic or :digest
+      :user       - user name to be used
+      :password   - password to be used
+      :realm      - realm name to authenticate in
+      :preemptive - assume authentication is required
     :timeout - request timeout in ms"
   {:tag Request}
   [method #^String url & {:keys [headers

--- a/src/clj/http/async/client/util.clj
+++ b/src/clj/http/async/client/util.clj
@@ -123,12 +123,8 @@
 
 (defn set-realm
   "Sets realm on builder."
-  [{type :type
-    user :user
-    password :password
-    realm :realm
-    :or {:type :basic}}
-   b]
+  [{:keys [type user password realm preemptive]
+    :or {:type :basic}} b]
   (let [rbld (Realm$RealmBuilder.)]
     (when (nil? user)
       (if (nil? password)
@@ -141,6 +137,8 @@
                                  "For DIGEST authentication realm is required")))
       (.setRealmName rbld realm)
       (.setScheme rbld Realm$AuthScheme/DIGEST))
+    (when (not (nil? preemptive))
+      (.setUsePreemptiveAuth rbld preemptive))
     (doto rbld
       (.setPrincipal user)
       (.setPassword password))

--- a/test/http/async/client/test.clj
+++ b/test/http/async/client/test.clj
@@ -103,6 +103,12 @@
                                 (if (= auth "Basic YmVhc3RpZTpib3lz")
                                   200
                                   401)))
+	       "/preemptive-auth" (let [auth (.getHeader hReq "Authorization")]
+				    (.setStatus
+				     hResp
+				     (if (= auth "Basic YmVhc3RpZTpib3lz")
+				       200
+				       401)))
                "/timeout" (Thread/sleep 2000)
                "/empty" (.setHeader hResp "Nothing" "Yep")
                (doseq [n (enumeration-seq (.getParameterNames hReq))]
@@ -473,6 +479,19 @@
        (:code (status (GET "http://localhost:8123/basic-auth"
                            :auth {:user "beastie"
                                   :password "boys"})))
+       200)))
+
+(deftest preemptive-authentication
+  (is (=
+       (:code (status (GET "http://localhost:8123/preemptive-auth"
+                           :auth {:user "beastie"
+                                  :password "boys"})))
+       401))
+  (is (=
+       (:code (status (GET "http://localhost:8123/preemptive-auth"
+                           :auth {:user "beastie"
+                                  :password "boys"
+				  :preemptive true})))
        200)))
 
 (deftest canceling-request


### PR DESCRIPTION
I was trying to use this to hit the campfire api (http://developer.37signals.com/campfire/streaming), and their streaming server does not request authentication.  It just expects you to send the request with authentication.

I've added {:preemptive boolean} to the auth map to allow for preemptive authorization, so that the library does not require the challenge first.  I left the default to false.  Perhaps using the auth map should default to true, but I did not want to introduce a behavior change.
