### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: clojure


### PR DESCRIPTION
We have noticed that you enabled travis-ci.org hook but haven't added .travis.yml as [described in the docs](http://about.travis-ci.org/docs/user/languages/clojure/). Without it travis cannot know this is a Clojure project.

I have [added my fork to travis](http://travis-ci.org/#!/michaelklishin/http.async.client) to demonstrate that it is all that's necessary for your project.
