### PR TITLE
0.4.0-SNAPSHOT does not exist on clojars

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Declare dependency:
 (defproject your-project "1.0.0-SNAPSHOT"
   :description "Your project description"
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [http.async.client "0.4.0-SNAPSHOT"]])
+                 [http.async.client "0.4.0"]])
 ```
 
 Require:


### PR DESCRIPTION
 Simply making sure that the :dependencies work as intended. 
