### PR TITLE
Fixes issue when parsing some cookies

### DIFF
--- a/src/clj/http/async/client/headers.clj
+++ b/src/clj/http/async/client/headers.clj
@@ -64,7 +64,8 @@
   "Creates cookies from headers."
   [headers]
   (if (contains? headers :set-cookie)
-    (for [cookie-string (:set-cookie headers)]
+    (for [cookie-string (let [set-cookie (:set-cookie headers)]
+                          (if (string? set-cookie) (vector set-cookie) set-cookie))]
       (let [name-token (atom true)]
         (into {}
               (for [#^String cookie (.split cookie-string ";")]

--- a/test/http/async/client/test.clj
+++ b/test/http/async/client/test.clj
@@ -136,7 +136,7 @@
            constraint (Constraint.)
            mapping (ConstraintMapping.)
            security (ConstraintSecurityHandler.)]
-       
+
        (.addBean srv loginSrv)
        (doto constraint
          (.setName Constraint/__BASIC_AUTH)
@@ -480,6 +480,16 @@
           r1 (GET client url)]
       (is (thrown-with-msg? RuntimeException #"Too many connections 1" (GET client url)))
       (is (not (failed? (await r1)))))))
+
+
+(deftest single-set-cookie
+  (let [resp (GET *client* "http://localhost:8123/cookie")
+        cookie (first (cookies resp))
+        header (headers resp)]
+    (is (string? (:set-cookie header)))
+    (is (= (:name cookie) "foo"))
+    (is (= (:value cookie) "bar"))))
+
 
 (deftest await-string
   (let [resp (GET *client* "http://localhost:8123/stream")


### PR DESCRIPTION
The current create-cookies function assumes that the 'set-cookie' header is always a vector.

I find out that this is not always true. If the response from the server contains a single 'set-cookie', the 'set-cookie' entry in the header map will be a string instead of a vector. This generates a java exception when the create-cookies function is called.

I wrote a new test to catch this scenario and changed the 'create-cookie' function to handle it.

Disclamer: I am Clojure newbie! I hope that everything is okay!

Thanks for the work you put on this library.

Cesar Canassa
