### PR TITLE
Fix shadowing of ws atom.

### DIFF
--- a/src/clj/http/async/client.clj
+++ b/src/clj/http/async/client.clj
@@ -333,8 +333,8 @@
   [ws openf closef errorf]
   (reify
     WebSocketCloseCodeReasonListener
-    (onClose [_ ws code reason]
-      (when closef (closef ws code reason))
+    (onClose [_ ws* code reason]
+      (when closef (closef ws* code reason))
       (reset! ws nil))
 
     WebSocketListener


### PR DESCRIPTION
I don't know whether `http.async.client` is still maintained, but it was nice if you could merge this fix and release a new version. 
Maybe you can also bump clojure and async-http-client versions if this doesn't break any tests?
