### PR TITLE
README.org updated. README.org websocket example updated issue #71

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,7 +70,8 @@
                              :open  on-open
                              :close on-close
                              :error on-error
-                             :byte  handle-message)]
+                             :byte  handle-message
+                             :text handle-message)]
       ; this loop-recur is here as a placeholder to keep the process
       ; from ending, so that the message-handling function will continue to
       ; print messages to STDOUT until Ctrl-C is pressed


### PR DESCRIPTION
As mentioned in Issue #71 , was unable to recognise messages sent using the existing readme.org example.