### PR TITLE
fix bad map :or destructuring - default not being applied

### DIFF
--- a/src/clj/http/async/client/util.clj
+++ b/src/clj/http/async/client/util.clj
@@ -50,7 +50,7 @@
   Note that in v.1.0.0 you must set a realm to enable HTTPS traffic
   via the proxy."
   [{:keys [type user password realm preemptive target-proxy]
-    :or {:type :basic}} b]
+    :or {type :basic}} b]
   (let [rbld (Realm$RealmBuilder.)]
     (.setScheme rbld (type->auth-scheme type))
     (when (nil? user)


### PR DESCRIPTION
In the :or map, the keys are the let-bound symbols, not the keys being looked up in the map.