### PR TITLE
Allow request options to be passed for websocket

### DIFF
--- a/src/clj/http/async/client.clj
+++ b/src/clj/http/async/client.clj
@@ -313,7 +313,7 @@
   {:tag WebSocket}
   [client #^String url & options]
   (let [wsugh (apply ws/upgrade-handler options)]
-    (.get (.executeRequest client (prepare-request :get url) wsugh))))
+    (.get (.executeRequest client (apply prepare-request :get url options) wsugh))))
 
 
 ;; closing


### PR DESCRIPTION
...again :)

I made this change a while back as issue #56. It was merged, but it looks like it was lost as a result of refactoring the websocket code. It's handy for me to be able to pass options (specifically a cookie id) on the upgrade request. Thanks!