### PR TITLE
Add protocol option to ssl-context

### DIFF
--- a/src/clj/http/async/client/cert.clj
+++ b/src/clj/http/async/client/cert.clj
@@ -126,6 +126,9 @@
    :certificate-alias - A name by which to access an X509 certificate that will
    be loaded into the KeyStore.
 
+   :protocol - The version of TLS to be used, by default \"TLS\", but \"TLSv1.1\"
+   or \"TLSv1.2\" are also supported
+
    :trust-managers - [optional] A seq of javax.net.ssl.X509TrustManager objects.
    These are used to verify the certificates sent by the remote host. If
    you don't specify this option, the connection will use an instance of
@@ -135,7 +138,9 @@
              keystore-password
              certificate-alias
              certificate-file
-             trust-managers]}]
+             trust-managers
+             protocol]
+      :or {protocol "TLS"}}]
   (let [initial-keystore (load-keystore
                           (when keystore-file (resource-stream keystore-file))
                           keystore-password)
@@ -144,7 +149,7 @@
                             certificate-alias
                             (load-x509-cert certificate-file))
         key-mgr-factory (key-manager-factory keystore-with-cert keystore-password)
-        ctx (SSLContext/getInstance "TLS")
+        ctx (SSLContext/getInstance protocol)
         key-managers (.getKeyManagers key-mgr-factory)
         trust-managers (into-array javax.net.ssl.X509TrustManager
                                    (or trust-managers


### PR DESCRIPTION
When setting up the `ssl-context` I need to use `TLSv1.2` or my request will fail. That is an optional parameter in the setup through the java api, but is not in your http async client. As result, on creation of the `ssl-context` it defaults to `TLS`. The proposed change would add an optional `:protocol` key to the `ssl-context` function which would default to `TLS` when not present, but could be specified.