### PR TITLE
[Fix #90] Allow for listening to both text and byte messages

### DIFF
--- a/src/clj/http/async/client/websocket.clj
+++ b/src/clj/http/async/client/websocket.clj
@@ -102,7 +102,6 @@
       open-cb  :open
       close-cb :close
       error-cb :error}]
-  {:pre [(not (and text-cb byte-cb))]}
   (let [b (WebSocketUpgradeHandler$Builder.)
         ws (atom nil)]
     (when text-cb (.addWebSocketListener b (create-text-listener ws text-cb open-cb close-cb error-cb)))

--- a/test/http/async/client_test.clj
+++ b/test/http/async/client_test.clj
@@ -884,4 +884,4 @@
 (deftest ws-xor-text-or-byte
   (let [ws (try (websocket *client* *ws-url* :text (fn [& _]) :byte (fn [& _]))
                 (catch java.lang.AssertionError e :boom))]
-    (is (= :boom ws))))
+    (is (not= :boom ws))))


### PR DESCRIPTION
We have a use case at work where we listen to both text and byte messages. This `pre` disallows that.
I'm not sure if there is a reason for disallowing, so please close if this is not a good idea.

Looking back into the old [issue](https://github.com/cch1/http.async.client/issues/73) that introduced this assertion, the underlying problem might now just be fixed because now there is only one listener created, and thus close should only be called once?